### PR TITLE
fix: update coords after changing properties

### DIFF
--- a/src/js/graphics.js
+++ b/src/js/graphics.js
@@ -592,6 +592,8 @@ class Graphics {
 
         object.set(clone);
 
+        object.setCoords();
+
         this.getCanvas().renderAll();
 
         return clone;
@@ -664,6 +666,8 @@ class Graphics {
             left: x + diffX,
             top: y + diffY
         });
+
+        targetObj.setCoords();
 
         return true;
     }


### PR DESCRIPTION
These apis `setObjectPosition`, `setObjectProperties` can set position/properties. But `fabric.Object.setCoords()` should be called to update `oCoords`

Resolves: #21