### PR TITLE
fix: add custom icon error

### DIFF
--- a/src/js/component/icon.js
+++ b/src/js/component/icon.js
@@ -61,44 +61,52 @@ class Icon extends Component {
             const canvas = this.getCanvas();
             const path = this._pathMap[type];
             const selectionStyle = consts.fObjectOptions.SELECTION_STYLE;
+            const isDefaultIconPath = Object.keys(consts.defaultIconPath).indexOf(type) >= 0;
+            const useDragAddIcon = this.useDragAddIcon && isDefaultIconPath;
+            const icon = path ? this._createIcon(path) : null;
 
-            if (!path) {
+            if (!icon) {
                 reject(rejectMessages.invalidParameters);
             }
-
-            const icon = this._createIcon(path);
 
             icon.set(snippet.extend({
                 type: 'icon',
                 fill: this._oColor
             }, selectionStyle, options, this.graphics.controlStyle));
 
-            if (this.useDragAddIcon) {
-                canvas.add(icon).setActiveObject(icon);
-                canvas.on({
-                    'mouse:move': fEvent => {
-                        canvas.selection = false;
+            canvas.add(icon).setActiveObject(icon);
 
-                        this.fire(events.ICON_CREATE_RESIZE, {
-                            moveOriginPointer: canvas.getPointer(fEvent.e)
-                        });
-                    },
-                    'mouse:up': fEvent => {
-                        this.fire(events.ICON_CREATE_END, {
-                            moveOriginPointer: canvas.getPointer(fEvent.e)
-                        });
-
-                        canvas.defaultCursor = 'default';
-                        canvas.off('mouse:up');
-                        canvas.off('mouse:move');
-                        canvas.selection = true;
-                    }
-                });
-            } else {
-                canvas.add(icon).setActiveObject(icon);
+            if (useDragAddIcon) {
+                this._addWithDrag(canvas);
             }
 
             resolve(this.graphics.createObjectProperties(icon));
+        });
+    }
+
+    /**
+     * Added icon drag
+     * @param {fabric.Canvas} canvas - Canvas instance
+     */
+    _addWithDrag(canvas) {
+        canvas.on({
+            'mouse:move': fEvent => {
+                canvas.selection = false;
+
+                this.fire(events.ICON_CREATE_RESIZE, {
+                    moveOriginPointer: canvas.getPointer(fEvent.e)
+                });
+            },
+            'mouse:up': fEvent => {
+                this.fire(events.ICON_CREATE_END, {
+                    moveOriginPointer: canvas.getPointer(fEvent.e)
+                });
+
+                canvas.defaultCursor = 'default';
+                canvas.off('mouse:up');
+                canvas.off('mouse:move');
+                canvas.selection = true;
+            }
         });
     }
 

--- a/test/icon.spec.js
+++ b/test/icon.spec.js
@@ -66,6 +66,31 @@ describe('Icon', () => {
         expect(icon._createIcon).toHaveBeenCalledWith(path);
     });
 
+    it('`_addWithDrag()` should be executed when `useDragAddIcon` is true.', () => {
+        const defaultIconKey = 'icon-arrow';
+        icon._pathMap[defaultIconKey] = true;
+
+        spyOn(icon, '_createIcon').and.returnValue(new fabric.Object({}));
+        spyOn(icon, '_addWithDrag');
+        spyOn(icon, 'useDragAddIcon').and.returnValue(true);
+
+        icon.add(defaultIconKey);
+
+        expect(icon._addWithDrag).toHaveBeenCalled();
+    });
+
+    it('`_addWithDrag()` should be not executed when target icon is not default icon.', () => {
+        const nonDefaultIconKey = 'non-default-icon';
+
+        spyOn(icon, '_createIcon').and.returnValue(new fabric.Object({}));
+        spyOn(icon, '_addWithDrag');
+        spyOn(icon, 'useDragAddIcon').and.returnValue(true);
+
+        icon.add(nonDefaultIconKey);
+
+        expect(icon._addWithDrag).not.toHaveBeenCalled();
+    });
+
     it('setColor() should change color of next inserted icon.', () => {
         let activeObj;
         const color = '#ffffff';


### PR DESCRIPTION
* 커스텀 아이콘 추가시 자바스크립트 에러가 발생되는 부분을 해결 (커스텀 아이콘은 drag로 추가되는 부분이 아니기때문에 dragevent가 생기면 안된다)
    - defaultIconPath에 포함된 타입이 아닐경우 이벤트가 발생하지 않도록 예외처리
    - 관련해서 add() 메서드 리팩토링 -  (_addDragWith()) 메서드를 추가하여 코드 분리
  