### PR TITLE
fix: load-image init event error

### DIFF
--- a/src/js/action.js
+++ b/src/js/action.js
@@ -84,10 +84,11 @@ export default {
                 }
 
                 this.ui.initializeImgUrl = URL.createObjectURL(file);
-                this.loadImageFromFile(file).then(() => {
+                this.loadImageFromFile(file).then(sizeValue => {
                     exitCropOnAction();
                     this.clearUndoStack();
-                    this.ui.resizeEditor();
+                    this.ui.activeMenuEvent();
+                    this.ui.resizeEditor({imageSize: sizeValue});
                 })['catch'](message => (
                     Promise.reject(message)
                 ));

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -38,7 +38,6 @@ const BI_EXPRESSION_MINSIZE_WHEN_TOP_POSITION = '1300';
  *   @param {Boolean} [option.menuBarPosition=bottom] - Let
  *   @param {Boolean} [option.applyCropSelectionStyle=false] - Let
  * @param {Objecdt} actions - ui action instance
- * @ignore
  */
 class Ui {
     constructor(element, options, actions) {
@@ -59,6 +58,7 @@ class Ui {
         this._subMenuElement = null;
         this._makeUiElement(element);
         this._setUiSize();
+        this._initMenuEvent = false;
 
         this._els = {
             'undo': this._menuElement.querySelector('#tie-btn-undo'),
@@ -77,6 +77,7 @@ class Ui {
      * Set Default Selection for includeUI
      * @param {Object} option - imageEditor options
      * @returns {Object} - extends selectionStyle option
+     * @ignore
      */
     setUiDefaultSelectionStyle(option) {
         return snippet.extend({
@@ -105,6 +106,7 @@ class Ui {
      *     @param {Number} resizeInfo.imageSize.oldHeight - old height
      *     @param {Number} resizeInfo.imageSize.newWidth - new width
      *     @param {Number} resizeInfo.imageSize.newHeight - new height
+     * @api
      */
     resizeEditor({uiSize, imageSize = this.imageSize} = {}) {
         if (imageSize !== this.imageSize) {
@@ -113,6 +115,7 @@ class Ui {
         if (uiSize) {
             this._setUiSize(uiSize);
         }
+
         const {width, height} = this._getEditorDimension();
         const editorElementStyle = this._editorElement.style;
         const {menuBarPosition} = this.options;
@@ -139,6 +142,7 @@ class Ui {
     /**
      * Change undo button status
      * @param {Boolean} enableStatus - enabled status
+     * @ignore
      */
     changeUndoButtonStatus(enableStatus) {
         if (enableStatus) {
@@ -151,6 +155,7 @@ class Ui {
     /**
      * Change redo button status
      * @param {Boolean} enableStatus - enabled status
+     * @ignore
      */
     changeRedoButtonStatus(enableStatus) {
         if (enableStatus) {
@@ -163,6 +168,7 @@ class Ui {
     /**
      * Change reset button status
      * @param {Boolean} enableStatus - enabled status
+     * @ignore
      */
     changeResetButtonStatus(enableStatus) {
         if (enableStatus) {
@@ -175,6 +181,7 @@ class Ui {
     /**
      * Change delete-all button status
      * @param {Boolean} enableStatus - enabled status
+     * @ignore
      */
     changeDeleteAllButtonEnabled(enableStatus) {
         if (enableStatus) {
@@ -187,6 +194,7 @@ class Ui {
     /**
      * Change delete button status
      * @param {Boolean} enableStatus - enabled status
+     * @ignore
      */
     changeDeleteButtonEnabled(enableStatus) {
         if (enableStatus) {
@@ -385,34 +393,50 @@ class Ui {
     /**
      * get editor area element
      * @returns {HTMLElement} editor area html element
+     * @ignore
      */
     getEditorArea() {
         return this._editorElement;
     }
 
     /**
+     * Add event for menu items
+     * @ignore
+     */
+    activeMenuEvent() {
+        if (this._initMenuEvent) {
+            return;
+        }
+
+        this._addHelpActionEvent('undo');
+        this._addHelpActionEvent('redo');
+        this._addHelpActionEvent('reset');
+        this._addHelpActionEvent('delete');
+        this._addHelpActionEvent('deleteAll');
+
+        this._addDownloadEvent();
+
+        snippet.forEach(this.options.menu, menuName => {
+            this._addMenuEvent(menuName);
+            this._addSubMenuEvent(menuName);
+        });
+        this._initMenu();
+        this._initMenuEvent = true;
+    }
+
+    /**
      * Init canvas
+     * @ignore
      */
     initCanvas() {
         const loadImageInfo = this._getLoadImage();
-        if (loadImageInfo) {
+        if (loadImageInfo.path) {
             this._actions.main.initLoadImage(loadImageInfo.path, loadImageInfo.name).then(() => {
-                this._addHelpActionEvent('undo');
-                this._addHelpActionEvent('redo');
-                this._addHelpActionEvent('reset');
-                this._addHelpActionEvent('delete');
-                this._addHelpActionEvent('deleteAll');
-
-                this._addDownloadEvent();
-                this._addLoadEvent();
-
-                snippet.forEach(this.options.menu, menuName => {
-                    this._addMenuEvent(menuName);
-                    this._addSubMenuEvent(menuName);
-                });
-                this._initMenu();
+                this.activeMenuEvent();
             });
         }
+
+        this._addLoadEvent();
 
         const gridVisual = document.createElement('div');
         gridVisual.className = 'tui-image-editor-grid-visual';
@@ -428,7 +452,7 @@ class Ui {
 
     /**
      * get editor area element
-     * @returns {Object} loadimage optionk
+     * @returns {Object} load image option
      * @private
      */
     _getLoadImage() {
@@ -440,6 +464,7 @@ class Ui {
      * @param {string} menuName - menu name
      * @param {boolean} toggle - whether toogle or not
      * @param {boolean} discardSelection - discard selection
+     * @ignore
      */
     changeMenu(menuName, toggle = true, discardSelection = true) {
         if (!this._submenuChangeTransection) {

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -106,7 +106,6 @@ class Ui {
      *     @param {Number} resizeInfo.imageSize.oldHeight - old height
      *     @param {Number} resizeInfo.imageSize.newWidth - new width
      *     @param {Number} resizeInfo.imageSize.newHeight - new height
-     * @api
      */
     resizeEditor({uiSize, imageSize = this.imageSize} = {}) {
         if (imageSize !== this.imageSize) {

--- a/test/ui.spec.js
+++ b/test/ui.spec.js
@@ -12,7 +12,7 @@ describe('UI', () => {
     beforeEach(() => {
         uiOptions = {
             loadImage: {
-                path: '',
+                path: 'mockImagePath',
                 name: ''
             },
             menu: ['crop', 'flip', 'rotate', 'draw', 'shape', 'icon', 'text', 'mask', 'filter'],
@@ -21,6 +21,7 @@ describe('UI', () => {
         };
         ui = new UI(document.createElement('div'), uiOptions, {});
     });
+
     describe('_changeMenu()', () => {
         beforeEach(() => {
             ui.submenu = 'shape';
@@ -65,8 +66,10 @@ describe('UI', () => {
     });
 
     describe('initCanvas()', () => {
-        it('When initCanvas is executed, some internal methods must be run as required.', done => {
-            const promise = new Promise(resolve => {
+        let promise;
+
+        beforeEach(() => {
+            promise = new Promise(resolve => {
                 resolve();
             });
             ui._editorElement = {
@@ -75,23 +78,35 @@ describe('UI', () => {
             ui._actions.main = {
                 initLoadImage: jasmine.createSpy('initLoadImage').and.returnValue(promise)
             };
+        });
 
-            spyOn(ui, '_addDownloadEvent');
+        it('When initCanvas is executed, some internal methods must be run as required.', done => {
+            spyOn(ui, 'activeMenuEvent');
             spyOn(ui, '_addLoadEvent');
-            spyOn(ui, '_addMenuEvent');
-            spyOn(ui, '_addSubMenuEvent');
-            spyOn(ui, '_addHelpActionEvent');
-            spyOn(ui, '_initMenu');
 
             ui.initCanvas();
             promise.then(() => {
-                expect(ui._addDownloadEvent).toHaveBeenCalled();
+                expect(ui.activeMenuEvent).toHaveBeenCalled();
                 expect(ui._addLoadEvent).toHaveBeenCalled();
-                expect(ui._addMenuEvent).toHaveBeenCalled();
-                expect(ui._addSubMenuEvent).toHaveBeenCalled();
-                expect(ui._addHelpActionEvent).toHaveBeenCalled();
                 done();
             });
+        });
+
+        it('`initLoadImage()` should not be run when has not image path.', () => {
+            spyOn(ui, '_getLoadImage').and.returnValue({path: ''});
+
+            ui.initCanvas();
+
+            expect(ui._actions.main.initLoadImage).not.toHaveBeenCalled();
+        });
+
+        it('`_AddLoadEvent()` should be executed even if there is no image path.', () => {
+            spyOn(ui, '_getLoadImage').and.returnValue({path: ''});
+            spyOn(ui, '_addLoadEvent');
+
+            ui.initCanvas();
+
+            expect(ui._addLoadEvent).toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
## work
- init 이미지가 없는 상태에서 이미지`Load` 버튼이 정상 동작하지 않는 문제를 수정
    - addLoadEvent() 를 초기 이미지가 없는 상태에서도 항상 호출하도록 변경
    - 초기 이미지가 없는 상태에서 이미지 로드시 이미지사이즈 상태를 업데이트 해주도록 변경
- ui.resizeEditor() 메서드를 api로 노출 하도록  jsdoc 수정

## demo
- http://10.78.9.21:8083/examples/example01-includeUi.html
