### PR TITLE
Fix: Fix width of tooltip when menu is left or right

### DIFF
--- a/src/css/position.styl
+++ b/src/css/position.styl
@@ -12,7 +12,7 @@
             &:after
                 top: 7px;
                 left: 39px;
-                width: 27px;
+                white-space: nowrap;
     .{prefix}-submenu
         left: 0;
         height: 100%;
@@ -88,7 +88,7 @@
             &:after
                 top: 7px;
                 left: -44px;
-                width: 27px;
+                white-space: nowrap;
     .{prefix}-submenu
         right: 0;
         height: 100%;


### PR DESCRIPTION
### Description

Currently the tooltip's get cut or weirdly wrapped when the menu is on the left or right:

<img width="167" alt="image" src="https://user-images.githubusercontent.com/81871/48737006-c7305480-ecb1-11e8-80a6-f4d641fa5fc9.png">

<img width="171" alt="image" src="https://user-images.githubusercontent.com/81871/48737017-cdbecc00-ecb1-11e8-8117-7b7c541aa8f5.png">

This patch removes the arbitrary width (not needed) and stops wrapping on the tooltips.
