### PR TITLE
feat: Remove jQuery selector method and jQuery elements from code

### DIFF
--- a/src/js/component/flip.js
+++ b/src/js/component/flip.js
@@ -37,7 +37,7 @@ class Flip extends Component {
     /**
      * Set flipX, flipY
      * @param {{flipX: Boolean, flipY: Boolean}} newSetting - Flip setting
-     * @returns {jQuery.Deferred}
+     * @returns {Promise}
      */
     set(newSetting) {
         const setting = this.getCurrentSetting();
@@ -110,7 +110,7 @@ class Flip extends Component {
 
     /**
      * Reset flip settings
-     * @returns {jQuery.Deferred}
+     * @returns {Promise}
      */
     reset() {
         return this.set({
@@ -121,7 +121,7 @@ class Flip extends Component {
 
     /**
      * Flip x
-     * @returns {jQuery.Deferred}
+     * @returns {Promise}
      */
     flipX() {
         const current = this.getCurrentSetting();
@@ -134,7 +134,7 @@ class Flip extends Component {
 
     /**
      * Flip y
-     * @returns {jQuery.Deferred}
+     * @returns {Promise}
      */
     flipY() {
         const current = this.getCurrentSetting();

--- a/src/js/component/imageLoader.js
+++ b/src/js/component/imageLoader.js
@@ -28,7 +28,7 @@ class ImageLoader extends Component {
      * Load image from url
      * @param {?string} imageName - File name
      * @param {?(fabric.Image|string)} img - fabric.Image instance or URL of an image
-     * @returns {jQuery.Deferred} deferred
+     * @returns {Promise}
      */
     load(imageName, img) {
         let promise;
@@ -58,7 +58,7 @@ class ImageLoader extends Component {
     /**
      * Set background image
      * @param {?(fabric.Image|String)} img fabric.Image instance or URL of an image to set background to
-     * @returns {$.Deferred} deferred
+     * @returns {Promise}
      * @private
      */
     _setBackgroundImage(img) {

--- a/src/js/component/rotation.js
+++ b/src/js/component/rotation.js
@@ -37,7 +37,7 @@ class Rotation extends Component {
      *      See "http://fabricjs.com/docs/fabric.Object.html#setAngle"
      *
      * @param {number} angle - Angle value
-     * @returns {jQuery.Deferred}
+     * @returns {Promise}
      */
     setAngle(angle) {
         const oldAngle = this.getCurrentAngle() % 360; // The angle is lower than 2*PI(===360 degrees)
@@ -86,7 +86,7 @@ class Rotation extends Component {
     /**
      * Rotate the image
      * @param {number} additionalAngle - Additional angle
-     * @returns {jQuery.Deferred}
+     * @returns {Promise}
      */
     rotate(additionalAngle) {
         const current = this.getCurrentAngle();

--- a/src/js/graphics.js
+++ b/src/js/graphics.js
@@ -42,7 +42,7 @@ const backstoreOnly = {
 /**
  * Graphics class
  * @class
- * @param {string|jQuery|HTMLElement} wrapper - Wrapper's element or selector
+ * @param {string|HTMLElement} wrapper - Wrapper's element or selector
  * @param {Object} [option] - Canvas max width & height of css
  *  @param {number} option.cssMaxWidth - Canvas css-max-width
  *  @param {number} option.cssMaxHeight - Canvas css-max-height
@@ -768,16 +768,14 @@ class Graphics {
 
     /**
      * Set canvas element to fabric.Canvas
-     * @param {jQuery|Element|string} element - Wrapper or canvas element or selector
+     * @param {Element|string} element - Wrapper or canvas element or selector
      * @private
      */
     _setCanvasElement(element) {
         let selectedElement;
         let canvasElement;
 
-        if (element.jquery) {
-            [selectedElement] = element;
-        } else if (element.nodeType) {
+        if (element.nodeType) {
             selectedElement = element;
         } else {
             selectedElement = document.querySelector(element);

--- a/src/js/imageEditor.js
+++ b/src/js/imageEditor.js
@@ -20,7 +20,7 @@ const {isUndefined, forEach, CustomEvents} = snippet;
 /**
  * Image editor
  * @class
- * @param {string|jQuery|HTMLElement} wrapper - Wrapper's element or selector
+ * @param {string|HTMLElement} wrapper - Wrapper's element or selector
  * @param {Object} [options] - Canvas max width & height of css
  *  @param {number} [options.includeUI] - Use the provided UI
  *    @param {Object} [options.includeUI.loadImage] - Basic editing image

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -32,7 +32,7 @@ const BI_EXPRESSION_MINSIZE_WHEN_TOP_POSITION = '1300';
 /**
  * Ui class
  * @class
- * @param {string|jQuery|HTMLElement} element - Wrapper's element or selector
+ * @param {string|HTMLElement} element - Wrapper's element or selector
  * @param {Object} [options] - Ui setting options
  *   @param {number} option.loadImage - Init default load image
  *   @param {number} option.initMenu - Init start menu
@@ -282,7 +282,7 @@ class Ui {
 
     /**
      * Make primary ui dom element
-     * @param {string|jQuery|HTMLElement} element - Wrapper's element or selector
+     * @param {string|HTMLElement} element - Wrapper's element or selector
      * @private
      */
     _makeUiElement(element) {
@@ -290,9 +290,7 @@ class Ui {
 
         window.snippet = snippet;
 
-        if (element.jquery) {
-            [selectedElement] = element;
-        } else if (element.nodeType) {
+        if (element.nodeType) {
             selectedElement = element;
         } else {
             selectedElement = document.querySelector(element);

--- a/test/command.spec.js
+++ b/test/command.spec.js
@@ -5,7 +5,6 @@
 import snippet from 'tui-code-snippet';
 import Promise from 'core-js/library/es6/promise';
 import fabric from 'fabric/dist/fabric.require';
-import $ from 'jquery';
 import Invoker from '../src/js/invoker';
 import commandFactory from '../src/js/factory/command';
 import Graphics from '../src/js/graphics';
@@ -17,7 +16,7 @@ describe('commandFactory', () => {
     let invoker, mockImage, canvas, graphics;
 
     beforeEach(() => {
-        graphics = new Graphics($('<canvas>')[0]);
+        graphics = new Graphics(document.createElement('canvas'));
         invoker = new Invoker();
         mockImage = new fabric.Image();
 

--- a/test/command.spec.js
+++ b/test/command.spec.js
@@ -17,7 +17,7 @@ describe('commandFactory', () => {
     let invoker, mockImage, canvas, graphics;
 
     beforeEach(() => {
-        graphics = new Graphics($('<canvas>'));
+        graphics = new Graphics($('<canvas>')[0]);
         invoker = new Invoker();
         mockImage = new fabric.Image();
 

--- a/test/drawingMode.spec.js
+++ b/test/drawingMode.spec.js
@@ -2,7 +2,6 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Test cases of "src/js/imageEditor.js"
  */
-import $ from 'jquery';
 import ImageEditor from '../src/js/imageEditor';
 
 describe('DrawingMode', () => {
@@ -10,7 +9,7 @@ describe('DrawingMode', () => {
     const imageURL = 'base/test/fixtures/sampleImage.jpg';
 
     beforeEach(done => {
-        imageEditor = new ImageEditor($('<div></div>'), {
+        imageEditor = new ImageEditor(document.createElement('div'), {
             cssMaxWidth: 700,
             cssMaxHeight: 500
         });

--- a/test/filter.spec.js
+++ b/test/filter.spec.js
@@ -10,7 +10,7 @@ describe('Filter', () => {
     const imageURL = 'base/test/fixtures/sampleImage.jpg';
 
     beforeAll(done => {
-        imageEditor = new ImageEditor($('<div></div>'), {
+        imageEditor = new ImageEditor(document.createElement('div'), {
             cssMaxWidth: 700,
             cssMaxHeight: 500
         });

--- a/test/graphics.spec.js
+++ b/test/graphics.spec.js
@@ -4,7 +4,6 @@
  */
 import snippet from 'tui-code-snippet';
 import fabric from 'fabric/dist/fabric.require';
-import $ from 'jquery';
 import Graphics from '../src/js/graphics';
 import consts from '../src/js/consts';
 
@@ -17,7 +16,7 @@ describe('Graphics', () => {
     let graphics, canvas;
 
     beforeEach(() => {
-        graphics = new Graphics($('<canvas>')[0], {
+        graphics = new Graphics(document.createElement('canvas'), {
             cssMaxWidth,
             cssMaxHeight
         });

--- a/test/graphics.spec.js
+++ b/test/graphics.spec.js
@@ -17,7 +17,7 @@ describe('Graphics', () => {
     let graphics, canvas;
 
     beforeEach(() => {
-        graphics = new Graphics($('<canvas>'), {
+        graphics = new Graphics($('<canvas>')[0], {
             cssMaxWidth,
             cssMaxHeight
         });

--- a/test/promiseApi.spec.js
+++ b/test/promiseApi.spec.js
@@ -2,7 +2,6 @@
  * @author NHN Ent. FE Development Team <dl_javascript@nhnent.com>
  * @fileoverview Test cases of "src/js/component/filter.js"
  */
-import $ from 'jquery';
 import ImageEditor from '../src/js/imageEditor';
 
 describe('Promise API', () => {
@@ -10,7 +9,7 @@ describe('Promise API', () => {
     const imageURL = 'base/test/fixtures/sampleImage.jpg';
 
     beforeAll(() => {
-        imageEditor = new ImageEditor($('<div></div>'), {
+        imageEditor = new ImageEditor(document.createElement('div'), {
             cssMaxWidth: 700,
             cssMaxHeight: 500
         });


### PR DESCRIPTION
jquery 레퍼로 싸여있는 엘리먼트 정보를 받을때, 타입스크립트 `index.d.ts` 타입 지원을 위해
"@types/jquery":  디펜던시를 추가해야 하는 이슈가 있으므로, 굳이 필요가 없는 jquery 레퍼 엘리먼트를 받는 부분을 제거하여 필요없는 디펜던시 추가를 막기 위해 수정하였습니다.