### PR TITLE
fix: Initialize UI defaultIcons without initial selected menu option. (fix #115)

### DIFF
--- a/src/css/buttons.styl
+++ b/src/css/buttons.styl
@@ -5,6 +5,7 @@
     &.icon-location .{prefix}-button[data-icontype="icon-location"] svg > use.active,
     &.icon-polygon .{prefix}-button[data-icontype="icon-polygon"] svg > use.active,
     &.icon-star .{prefix}-button[data-icontype="icon-star"] svg > use.active,
+    &.icon-star-2 .{prefix}-button[data-icontype="icon-star-2"] svg > use.active,
     &.icon-arrow-3 .{prefix}-button[data-icontype="icon-arrow-3"] svg > use.active,
     &.icon-arrow-2 .{prefix}-button[data-icontype="icon-arrow-2"] svg > use.active,
     &.icon-arrow .{prefix}-button[data-icontype="icon-arrow"] svg > use.active,

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -219,10 +219,10 @@ class Ui {
     /**
      * Change delete button status
      * @param {Object} [options] - Ui setting options
-     *   @param {number} option.loadImage - Init default load image
-     *   @param {number} option.initMenu - Init start menu
-     *   @param {Boolean} [option.menuBarPosition=bottom] - Let
-     *   @param {Boolean} [option.applyCropSelectionStyle=false] - Let
+     *   @param {object} [option.loadImage] - Init default load image
+     *   @param {string} [option.initMenu] - Init start menu
+     *   @param {string} [option.menuBarPosition=bottom] - Let
+     *   @param {boolean} [option.applyCropSelectionStyle=false] - Let
      * @returns {Object} initialize option
      * @private
      */
@@ -235,7 +235,7 @@ class Ui {
             locale: {},
             menuIconPath: '',
             menu: ['crop', 'flip', 'rotate', 'draw', 'shape', 'icon', 'text', 'mask', 'filter'],
-            initMenu: false,
+            initMenu: '',
             uiSize: {
                 width: '100%',
                 height: '100%'
@@ -529,9 +529,10 @@ class Ui {
             const evt = document.createEvent('MouseEvents');
             evt.initEvent('click', true, false);
             this._els[this.options.initMenu].dispatchEvent(evt);
-            if (this.icon) {
-                this.icon.registDefaultIcon();
-            }
+        }
+
+        if (this.icon) {
+            this.icon.registDefaultIcon();
         }
     }
 

--- a/src/js/ui/template/style.js
+++ b/src/js/ui/template/style.js
@@ -23,6 +23,7 @@ export default ({
     #tie-icon-add-button.icon-location .tui-image-editor-button[data-icontype="icon-location"] label,
     #tie-icon-add-button.icon-polygon .tui-image-editor-button[data-icontype="icon-polygon"] label,
     #tie-icon-add-button.icon-star .tui-image-editor-button[data-icontype="icon-star"] label,
+    #tie-icon-add-button.icon-star-2 .tui-image-editor-button[data-icontype="icon-star-2"] label,
     #tie-icon-add-button.icon-arrow-3 .tui-image-editor-button[data-icontype="icon-arrow-3"] label,
     #tie-icon-add-button.icon-arrow-2 .tui-image-editor-button[data-icontype="icon-arrow-2"] label,
     #tie-icon-add-button.icon-arrow .tui-image-editor-button[data-icontype="icon-arrow"] label,


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

Issue: #115 

#### Bug fix
- Initialize and register default icon sets regardless `initMenu` option's value
- Add button svg for `icon-start-2`

#### Chore
- Correct mistyped JSDoc parameter types

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨