### PR TITLE
fix: Change loadButton tag to div (fix #137)

### DIFF
--- a/src/css/main.styl
+++ b/src/css/main.styl
@@ -48,7 +48,9 @@ body > textarea
         display: none;
 
     .-header-buttons button,
+    .-header-buttons div,
     .-controls-buttons button
+        display: inline-block;
         position: relative;
         width: 120px;
         height: 40px;
@@ -63,6 +65,7 @@ body > textarea
         cursor: pointer;
         vertical-align: middle;
         letter-spacing: 0.3px;
+        text-align: center;
 
     .-download-btn
         background-color: #fdba3b;

--- a/src/js/ui/template/controls.js
+++ b/src/js/ui/template/controls.js
@@ -48,10 +48,10 @@ export default ({locale, biImage, iconStyle: {normal, hover, disabled}, loadButt
         </ul>
 
         <div class="tui-image-editor-controls-buttons">
-            <button style="${loadButtonStyle}">
+            <div style="${loadButtonStyle}">
                 ${locale.localize('Load')}
                 <input type="file" class="tui-image-editor-load-btn" />
-            </button>
+            </div>
             <button class="tui-image-editor-download-btn" style="${downloadButtonStyle}">
                 ${locale.localize('Download')}
             </button>

--- a/src/js/ui/template/mainContainer.js
+++ b/src/js/ui/template/mainContainer.js
@@ -5,10 +5,10 @@ export default ({locale, biImage, commonStyle, headerStyle, loadButtonStyle, dow
                 <img src="${biImage}" />
             </div>
             <div class="tui-image-editor-header-buttons">
-                <button style="${loadButtonStyle}">
+                <div style="${loadButtonStyle}">
                     ${locale.localize('Load')}
                     <input type="file" class="tui-image-editor-load-btn" />
-                </button>
+                </div>
                 <button class="tui-image-editor-download-btn" style="${downloadButtonStyle}">
                     ${locale.localize('Download')}
                 </button>


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

Change UI Load button Tag 'button' to 'div'.
Because of input tag in button tag is invalid html, the button in Firefox does not working as expected. 

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨