### PR TITLE
fix: Do not fire "changeShow" event when ColorPicker's color not changed (fix #131)

### DIFF
--- a/src/js/ui/tools/colorpicker.js
+++ b/src/js/ui/tools/colorpicker.js
@@ -133,15 +133,54 @@ class Colorpicker {
             this.fire('change', value.color);
         });
         colorpickerElement.addEventListener('click', event => {
-            this._show = !this._show;
-            this.pickerControl.style.display = this._show ? 'block' : 'none';
-            this._setPickerControlPosition();
-            this.fire('changeShow', this);
+            const {target} = event;
+            const isInPickerControl = target && this._isElementInColorPickerControl(target);
+
+            if (!isInPickerControl || (isInPickerControl && this._isPaletteButton(target))) {
+                this._show = !this._show;
+                this.pickerControl.style.display = this._show ? 'block' : 'none';
+                this._setPickerControlPosition();
+                this.fire('changeShow', this);
+            }
             event.stopPropagation();
         });
         document.body.addEventListener('click', () => {
             this.hide();
         });
+    }
+
+    /**
+     * Check hex input or not
+     * @param {Element} target - Event target element
+     * @returns {boolean}
+     * @private
+     */
+    _isPaletteButton(target) {
+        return target.className === 'tui-colorpicker-palette-button';
+    }
+
+    /**
+     * Check given element is in pickerControl element
+     * @param {Element} element - element to check
+     * @returns {boolean}
+     * @private
+     */
+    _isElementInColorPickerControl(element) {
+        let parentNode = element;
+
+        while (parentNode !== document.body) {
+            if (!parentNode) {
+                break;
+            }
+
+            if (parentNode === this.pickerControl) {
+                return true;
+            }
+
+            parentNode = parentNode.parentNode;
+        }
+
+        return false;
     }
 
     hide() {


### PR DESCRIPTION


<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

Change show state when color changes & initial color-picker opening.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨