### PR TITLE
fix: Change module exporting type (fix #159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,23 @@ var instance = new ImageEditor(document.querySelector('#tui-image-editor'), {
 });
 ```
 
+### TypeScript
+If you using TypeScript, You must `import module = require('module')` on importing.
+[`export =` and `import = require()`](https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require)
+
+```typescript
+import ImageEditor = require('tui-image-editor');
+
+const instance = new ImageEditor(document.querySelector('#tui-image-editor'), {
+    cssMaxWidth: 700,
+    cssMaxHeight: 500,
+    selectionStyle: {
+        cornerSize: 20,
+        rotatingPointOffset: 70
+    }
+});
+```
+
 See [details](https://nhnent.github.io/tui.image-editor/latest) for additional informations.
 
 ## 🔧 Development

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for TOAST UI Image Editor v3.4.0
+// Type definitions for TOAST UI Image Editor v3.5.1
 // TypeScript Version: 3.2.2
 
 declare namespace tuiImageEditor {
@@ -270,7 +270,7 @@ declare namespace tuiImageEditor {
         public removeFilter(type?: string): Promise<IFilterResolveObject>;
         public removeObject(id: number): Promise<void>;
         public resetFlip(): Promise<IFlipXYResolveObject>;
-        public resizeCanvasDemension(dimension: ICanvasSize): Promise<void>;
+        public resizeCanvasDimension(dimension: ICanvasSize): Promise<void>;
         public rotate(angle: AngleType): Promise<AngleType>;
         public setAngle(angle: AngleType): Promise<AngleType>;
         public setBrush(option: IBrushOptions): void;
@@ -288,5 +288,5 @@ declare namespace tuiImageEditor {
 }
 
 declare module 'tui-image-editor' {
-    export default tuiImageEditor.ImageEditor;
+    export = tuiImageEditor.ImageEditor;
 }

--- a/test/types/type-tests.ts
+++ b/test/types/type-tests.ts
@@ -1,4 +1,4 @@
-import ImageEditor from 'tui-image-editor';
+import ImageEditor = require('tui-image-editor');
 
 const blackTheme = {
     'common.bi.image': 'https://uicdn.toast.com/toastui/img/tui-image-editor-bi.png',
@@ -230,7 +230,7 @@ imageEditor.resetFlip().then(status => {
     console.log(`angle : ${status.angle}`);
 });
 
-imageEditor.resizeCanvasDemension({
+imageEditor.resizeCanvasDimension({
     width: 300,
     height: 300
 });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description
In typescript, to import module by replacing entire exports object(`module.exports  = {}`) must use `import someModule = require('that-module');`. [ref.](https://www.typescriptlang.org/docs/handbook/modules.html)
`module.exports = {}` is not equivalent `export default {}`. Default export matches `module.exports.default = {}`.

#### case 1. Replacing exports
```js
module.exports = ImageEditor;
// --------------------------------------

import ImageEditor = require('tui-image-editor');
```

#### case 2. Default export
```js
module.exports.default = ImageEditor;
// or
export default ImageEditor;
// --------------------------------------

import ImageEditor from 'tui-image-editor';
```

Change module exporting type `default` to commonjs pattern.
ref: #159 

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨